### PR TITLE
feat: add ability to set empty output

### DIFF
--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -132,7 +132,7 @@ jobs:
     - name: bumping version
       id: next_vars
       run: |
-        ./mvnw validate -DchangeVersionPatch
+        ./mvnw -B validate -DchangeVersionPatch
         echo ::set-output name=next_version::$(./mvnw -q validate -DcurrentVersion)
         echo ::set-output name=next_released_version::$(./mvnw -q validate -DcurrentReleaseVersion)
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ It is heavily inspired of GitHub Actions [core toolkit](https://github.com/actio
 This SDK provides the following capabilities:
 
 * Read inputs: `getInput`, `getMultilineInput`, `getBooleanInput`
-* Write output variables: `setOutput`
+* Write output variables: `setOutput`, `setEmptyOutput`
 * Mask secret variables: `setSecret`
 * Run operations within groups: `startGroup`, `endGroup`, `group` with closure
 * Save and retrieve state: `saveState`, `getState`

--- a/src/main/java/me/julb/sdk/github/actions/kit/GitHubActionsKit.java
+++ b/src/main/java/me/julb/sdk/github/actions/kit/GitHubActionsKit.java
@@ -218,6 +218,14 @@ public class GitHubActionsKit {
     }
 
     /**
+     * Sets the given output variable with an empty value.
+     * @param name the output variable name.
+     */
+    public void setEmptyOutput(@NonNull String name) {
+        issue("set-output", Map.of("name", name));
+    }
+
+    /**
      * Enables or disables the echoing of commands into STDOUT for the rest of the step.<br>
      * Echoing is disabled by default if ACTIONS_STEP_DEBUG is not set.
      * @param enabled <code>true</code> to enable, <code>false</code> otherwise.
@@ -504,6 +512,17 @@ public class GitHubActionsKit {
      */
     private <M> void issue(String command, M message) {
         issueCommand(command, Optional.empty(), Optional.of(message));
+    }
+
+    /**
+     * Issue the command with the properties.
+     * @param <P> the property value object type.
+     * @param command the command to execute.
+     * @param properties the properties to attach.
+     * @param message the message to attach.
+     */
+    private <P> void issue(String command, Map<String, P> properties) {
+        issueCommand(command, Optional.of(properties), Optional.empty());
     }
 
     /**

--- a/src/test/java/me/julb/sdk/github/actions/kit/GitHubActionsKitTest.java
+++ b/src/test/java/me/julb/sdk/github/actions/kit/GitHubActionsKitTest.java
@@ -716,6 +716,26 @@ class GitHubActionsKitTest {
      * Test method.
      */
     @Test
+    void whenSetEmptyOutput_thenPrintCommand()
+        throws Exception {
+        this.gitHubActionsKit.setEmptyOutput("variable");
+        verify(this.systemProxyMock).println("::set-output name=variable::");
+        reset(this.systemProxyMock);
+    }
+
+    /**
+     * Test method.
+     */
+    @Test
+    void whenSetEmptyOutputNull_thenThrowNullPointerException()
+        throws Exception {
+        assertThrows(NullPointerException.class, () -> this.gitHubActionsKit.setEmptyOutput(null));
+    }
+
+    /**
+     * Test method.
+     */
+    @Test
     void whenSetCommandEchoEnabled_thenPrintCommand()
         throws Exception {
         this.gitHubActionsKit.setCommandEcho(true);


### PR DESCRIPTION
GitHub action may need to output empty variables. A method
setEmptyOutput(varName) is made available.